### PR TITLE
Move pane 4 dev branch to 2 column layout

### DIFF
--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -83,19 +83,35 @@ for (i in (1:length(station_choices)))
                                       ")")
 
 ui <- page_fluid(
+  layout_columns(
+    card(titlePanel("Placeholder")),
+    card(actionButton("help_4",
+                      "Help")),
+    col_widths = c(6,-3,3)
+  ),
   card(selectInput("select_station_4",
                    "Select Station:",
                    choices = station_choices,
                    selected = 7000)),
-  girafeOutput("plot_yearly_swise_start"),
-  girafeOutput("plot_yearly_swise_end"),
-  girafeOutput("plot_monthly_swise_start"),
-  girafeOutput("plot_monthly_swise_end"),
-  girafeOutput("plot_daily_swise_start"),
-  girafeOutput("plot_daily_swise_end")
+  layout_column_wrap(
+    width = 1/2,
+    girafeOutput("plot_yearly_swise_start"),
+    girafeOutput("plot_yearly_swise_end"),
+    girafeOutput("plot_monthly_swise_start"),
+    girafeOutput("plot_monthly_swise_end"),
+    girafeOutput("plot_daily_swise_start"),
+    girafeOutput("plot_daily_swise_end")
+  )
 )
 
 server <- function(input, output, session){
+  
+  observeEvent(input$help_4, {
+    showModal(modalDialog(
+      title = "How this pane works",
+      HTML("Placeholder")
+    ))
+  })
   
   # YEARLY DATA----
   

--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -310,7 +310,7 @@ server <- function(input, output, session){
                           use_stroke = TRUE),
              opts_hover(css = "stroke-width:2;"),
              opts_hover_inv(css = "opacity:0.3;"),
-             opts_selection(selected = as.Date(selected_day()),
+             opts_selection(selected = as.Date(selected_month()),
                             type = "single",
                             css = "stroke:black;stroke-width:2px")
            ))
@@ -376,7 +376,7 @@ server <- function(input, output, session){
                           use_stroke = TRUE),
              opts_hover(css = "stroke-width:2;"),
              opts_hover_inv(css = "opacity:0.3;"),
-             opts_selection(selected = as.Date(selected_day()),
+             opts_selection(selected = as.Date(selected_month()),
                             type = "single",
                             css = "stroke:black;stroke-width:2px")
            ))

--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -84,7 +84,7 @@ for (i in (1:length(station_choices)))
 
 ui <- page_fluid(
   layout_columns(
-    card(titlePanel("Placeholder")),
+    card(titlePanel("Trips by Station")),
     card(actionButton("help_4",
                       "Help")),
     col_widths = c(6,-3,3)
@@ -98,12 +98,18 @@ ui <- page_fluid(
                    selected = 7000)),
   layout_column_wrap(
     width = 1/2,
-    card(girafeOutput("plot_yearly_swise_start")),
-    card(girafeOutput("plot_yearly_swise_end")),
-    card(girafeOutput("plot_monthly_swise_start")),
-    card(girafeOutput("plot_monthly_swise_end")),
-    card(girafeOutput("plot_daily_swise_start")),
-    card(girafeOutput("plot_daily_swise_end"))
+    card(card_header("Trips Started by Month"),
+         girafeOutput("plot_yearly_swise_start")),
+    card(card_header("Trips Ended by Month"), 
+         girafeOutput("plot_yearly_swise_end")),
+    card(card_header("Trips Started by Day"),
+         girafeOutput("plot_monthly_swise_start")),
+    card(card_header("Trips Ended by Day"),
+         girafeOutput("plot_monthly_swise_end")),
+    card(card_header("Trips Started by Hour"),
+         girafeOutput("plot_daily_swise_start")),
+    card(card_header("Trips Ended by Hour"),
+         girafeOutput("plot_daily_swise_end"))
   )
 )
 

--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -89,18 +89,21 @@ ui <- page_fluid(
                       "Help")),
     col_widths = c(6,-3,3)
   ),
-  card(selectInput("select_station_4",
+  card(tags$head(
+    tags$style(HTML("#select_station_4+ div>.selectize-dropdown {position: unset;}"))
+  ),
+    selectInput("select_station_4",
                    "Select Station:",
                    choices = station_choices,
                    selected = 7000)),
   layout_column_wrap(
     width = 1/2,
-    girafeOutput("plot_yearly_swise_start"),
-    girafeOutput("plot_yearly_swise_end"),
-    girafeOutput("plot_monthly_swise_start"),
-    girafeOutput("plot_monthly_swise_end"),
-    girafeOutput("plot_daily_swise_start"),
-    girafeOutput("plot_daily_swise_end")
+    card(girafeOutput("plot_yearly_swise_start")),
+    card(girafeOutput("plot_yearly_swise_end")),
+    card(girafeOutput("plot_monthly_swise_start")),
+    card(girafeOutput("plot_monthly_swise_end")),
+    card(girafeOutput("plot_daily_swise_start")),
+    card(girafeOutput("plot_daily_swise_end"))
   )
 )
 

--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -83,17 +83,15 @@ for (i in (1:length(station_choices)))
                                       ")")
 
 ui <- page_fluid(
-  layout_columns(
-    card(titlePanel("Placeholder")),
-    # card(actionButton("help_4",
-    #                   "Help")),
-    col_widths = c(6,-3,3)),
-  card(card_header = "Select Station",
-       card_body(class = "align-items_center",
-                 selectInput("select_station_4",
+  # layout_columns(
+  #   card(titlePanel("Placeholder")),
+  #   # card(actionButton("help_4",
+  #   #                   "Help")),
+  #   col_widths = c(6,-3,3)),
+  card(selectInput("select_station_4",
                              "Select Station:",
                              choices = station_choices,
-                             selected = 7000))),
+                             selected = 7000)),
   layout_column_wrap(width = 1/2,
                      card(card_header = "Trips Started by Month",
                           card_body = girafeOutput("plot_yearly_swise_start")),
@@ -151,7 +149,7 @@ server <- function(input, output, session){
       replace_na(list(n = 0))
   })
   
-  output$plot_yearly_stationwise <- renderGirafe({
+  output$plot_yearly_swise_start <- renderGirafe({
     p_y <- ggplot(yearly_rides_swise_start(), aes(x = trip_month,
                                             y = n,
                                             group = User.Type,
@@ -207,7 +205,7 @@ server <- function(input, output, session){
       replace_na(list(n = 0))
   })
   
-  output$plot_yearly_stationwise <- renderGirafe({
+  output$plot_yearly_swise_end <- renderGirafe({
     p_y <- ggplot(yearly_rides_swise_end(), aes(x = trip_month,
                                                 y = n,
                                                 group = User.Type,
@@ -243,10 +241,10 @@ server <- function(input, output, session){
   
   # MONTHLY DATA----
 
-  selected_day <- reactiveVal("2022-01-01")
+  selected_day <- reactiveVal(value = NULL)
   
   observeEvent(selected_month(),{
-    temp_day <- selected_month
+    temp_day <- selected_month()
     selected_day(temp_day)
   })
   

--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -99,7 +99,7 @@ server <- function(input, output, session){
   
   # YEARLY DATA----
   
-  selected_month <- reactiveVal(value = "2022-01-01")
+  selected_month <- reactiveVal(value = NULL)
   
   observeEvent(selected_month(), {
     session$sendCustomMessage(type = 'plot_yearly_swise_start_set',
@@ -165,7 +165,7 @@ server <- function(input, output, session){
                                        use_stroke = TRUE),
                           opts_hover(css = "stroke:white;stroke-width:2px"),
                           opts_hover_inv(css = "opacity:0.3;"),
-                          opts_selection(selected = selected_month(),
+                          opts_selection(selected = "2022-01-01",
                                          type = "single",
                                          css = "stroke:black;stroke-width:2px")
            ))
@@ -221,7 +221,7 @@ server <- function(input, output, session){
                                        use_stroke = TRUE),
                           opts_hover(css = "stroke:white;stroke-width:2px"),
                           opts_hover_inv(css = "opacity:0.3;"),
-                          opts_selection(selected = selected_month(),
+                          opts_selection(selected = "2022-01-01",
                                          type = "single",
                                          css = "stroke:black;stroke-width:2px")
            ))

--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -302,17 +302,19 @@ server <- function(input, output, session){
   
   output$plot_monthly_swise_start <- renderGirafe({
     req(monthly_rides_swise_start())
+    jitterer <- position_jitter(width = 0.2, height = 0, seed = 123)
     p_m <- ggplot(monthly_rides_swise_start(), aes(x = trip_date,
                                                    y = n,
                                                    group = User.Type,
                                                    colour = User.Type
     )) +
-      geom_line_interactive() +
+      geom_line(position = jitterer) +
       geom_point_interactive(aes(tooltip = glue("{strftime(trip_date, format = '%a, %b %d')}<br/>",
                                                 "{User.Type}<br/>",
                                                 "{n} Trips<br/>"
       ),
-      data_id = trip_date)) +
+      data_id = trip_date),
+      position = jitterer) +
       labs(title = glue("{month(as.Date(selected_month()), label = TRUE)} {year(as.Date(selected_month()))}"),
            x = "Date",
            y = "Number of Trips",
@@ -369,17 +371,19 @@ server <- function(input, output, session){
   
   output$plot_monthly_swise_end <- renderGirafe({
     req(monthly_rides_swise_end())
+    jitterer <- position_jitter(width = 0.2, height = 0, seed = 123)
     p_m <- ggplot(monthly_rides_swise_end(), aes(x = trip_date,
                                                  y = n,
                                                  group = User.Type,
                                                  colour = User.Type
     )) +
-      geom_line_interactive() +
+      geom_line(position = jitterer) +
       geom_point_interactive(aes(tooltip = glue("{strftime(trip_date, format = '%a, %b %d')}<br/>",
                                                 "{User.Type}<br/>",
                                                 "{n} Trips<br/>"
       ),
-      data_id = trip_date)) +
+      data_id = trip_date),
+      position = jitterer) +
       labs(title = glue("{month(as.Date(selected_month()), label = TRUE)} {year(as.Date(selected_month()))}"),
            x = "Date",
            y = "Number of Trips",

--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -83,22 +83,52 @@ for (i in (1:length(station_choices)))
                                       ")")
 
 ui <- page_fluid(
-  selectInput("select_station_4",
-              "Select Station:",
-              choices = station_choices,
-              selected = 7000),
-  girafeOutput("plot_yearly_stationwise"),
-  girafeOutput("plot_monthly_stationwise"),
-  girafeOutput("plot_daily_stationwise")
+  layout_columns(
+    card(titlePanel("Placeholder")),
+    # card(actionButton("help_4",
+    #                   "Help")),
+    col_widths = c(6,-3,3)),
+  card(card_header = "Select Station",
+       card_body(class = "align-items_center",
+                 selectInput("select_station_4",
+                             "Select Station:",
+                             choices = station_choices,
+                             selected = 7000))),
+  layout_column_wrap(width = 1/2,
+                     card(card_header = "Trips Started by Month",
+                          card_body = girafeOutput("plot_yearly_swise_start")),
+                     card(card_header = "Trips Ended by Month",
+                          card_body = girafeOutput("plot_yearly_swise_end")),
+                     card(card_header = "Trips Started by Day",
+                          card_body = girafeOutput("plot_monthly_swise_start")),
+                     card(card_header = "Trips Ended by Day",
+                          card_body = girafeOutput("plot_monthly_swise_end")),
+                     card(card_header = "Trips Started by Hour",
+                          card_body = girafeOutput("plot_daily_swise_start")),
+                     card(card_header = "Trips Ended by Hour",
+                          card_body = girafeOutput("plot_daily_swise_end")))
 )
-
 server <- function(input, output, session){
   
-  session$onFlushed(function(){
-    session$sendCustomMessage(type = 'plot_yearly_stationwise_set', message = "2022-01-01")
+  # YEARLY DATA----
+  
+  selected_month <- reactiveVal(value = "2022-01-01")
+  
+  observeEvent(selected_month(), {
+    session$sendCustomMessage(type = 'plot_yearly_swise_start_set',
+                              message = selected_month())
+    session$sendCustomMessage(type = 'plot_yearly_swise_end_set',
+                              message = selected_month())
   })
   
-  yearly_rides_stationwise <- reactive({
+  observeEvent(input$plot_yearly_swise_start_selected, {
+    selected_month(input$plot_yearly_swise_start_selected)
+  })
+  observeEvent(input$plot_yearly_swise_end_selected, {
+    selected_month(input$plot_yearly_swise_end_selected)
+  })
+  
+  yearly_rides_swise_start <- reactive({
     rides_2022_dset %>%
       filter(Start.Station.Id == as.numeric(!!input$select_station_4)) %>%
       mutate(trip_month = as.Date(floor_date(Start.Time, unit = "month"))) %>%
@@ -122,7 +152,7 @@ server <- function(input, output, session){
   })
   
   output$plot_yearly_stationwise <- renderGirafe({
-    p_y <- ggplot(yearly_rides_stationwise(), aes(x = trip_month,
+    p_y <- ggplot(yearly_rides_swise_start(), aes(x = trip_month,
                                             y = n,
                                             group = User.Type,
                                             fill = User.Type)) +
@@ -148,40 +178,119 @@ server <- function(input, output, session){
                                        use_stroke = TRUE),
                           opts_hover(css = "stroke:white;stroke-width:2px"),
                           opts_hover_inv(css = "opacity:0.3;"),
-                          opts_selection(selected = input$plot_yearly_stationwise_selected,
+                          opts_selection(selected = selected_month(),
                                          type = "single",
                                          css = "stroke:black;stroke-width:2px")
            ))
   })
-
-  monthly_rides_stationwise <- reactive({
-    req(!(is.null(input$plot_yearly_stationwise_selected)))
+  
+  yearly_rides_swise_end<- reactive({
     rides_2022_dset %>%
-      filter(month(Start.Time) == month(as.Date(!!input$plot_yearly_stationwise_selected)) & Start.Station.Id == as.numeric(!!input$select_station_4)) %>%
+      filter(End.Station.Id == as.numeric(!!input$select_station_4)) %>%
+      mutate(trip_month = as.Date(floor_date(End.Time, unit = "month"))) %>%
+      group_by(trip_month, User.Type) %>%
+      count() %>%
+      collect() %>%
+      group_by(User.Type) %>%
+      complete(trip_month = seq.Date(from = as.Date("2022-01-01"),
+                                     to = as.Date("2022-12-31"),
+                                     by = "month")) %>%
+      union_all(rides_2022_dset %>%
+                  filter(End.Station.Id == as.numeric(!!input$select_station_4)) %>%
+                  mutate(trip_month = as.Date(floor_date(End.Time, unit = "month"))) %>%
+                  count(trip_month) %>%
+                  collect() %>%
+                  complete(trip_month = seq.Date(from = as.Date("2022-01-01"),
+                                                 to = as.Date("2022-12-31"),
+                                                 by = "month")) %>%
+                  mutate(User.Type = "Total", .before = 1)) %>%
+      replace_na(list(n = 0))
+  })
+  
+  output$plot_yearly_stationwise <- renderGirafe({
+    p_y <- ggplot(yearly_rides_swise_end(), aes(x = trip_month,
+                                                y = n,
+                                                group = User.Type,
+                                                fill = User.Type)) +
+      geom_bar_interactive(aes(data_id = trip_month,
+                               tooltip = glue("{month(trip_month, label = TRUE)}<br/>",
+                                              "{User.Type}<br/>",
+                                              "{n} Trips<br/>",
+                               )),
+                           position = "dodge",
+                           stat = "identity") +
+      labs(x = "Month",
+           y = "Number of Trips",
+           fill = "User Type") +
+      scale_x_date(date_breaks = "1 month",
+                   date_labels = "%b") +
+      scale_fill_manual(values = pal_pane_4,
+                        limits = names(pal_pane_4)) +
+      theme_bikeshare() +
+      theme(axis.ticks.x = element_line())
+    
+    girafe(ggobj = p_y,
+           options = list(opts_tooltip(use_fill = TRUE,
+                                       use_stroke = TRUE),
+                          opts_hover(css = "stroke:white;stroke-width:2px"),
+                          opts_hover_inv(css = "opacity:0.3;"),
+                          opts_selection(selected = selected_month(),
+                                         type = "single",
+                                         css = "stroke:black;stroke-width:2px")
+           ))
+  })
+  
+  
+  # MONTHLY DATA----
+
+  selected_day <- reactiveVal("2022-01-01")
+  
+  observeEvent(selected_month(),{
+    temp_day <- selected_month
+    selected_day(temp_day)
+  })
+  
+  observeEvent(selected_day(), {
+    session$sendCustomMessage(type = "plot_monthly_swise_start_set", message = selected_day())
+    session$sendCustomMessage(type = "plot_monthly_swise_end_set", message = selected_day())
+  })
+  
+  observeEvent(input$plot_monthly_swise_start_selected, {
+    selected_day(input$plot_monthly_swise_start_selected)
+  })
+  observeEvent(input$plot_monthly_swise_end_selected, {
+    selected_day(input$plot_monthly_swise_end_selected)
+  })
+  
+  
+  monthly_rides_swise_start <- reactive({
+    req(!(is.null(selected_month())))
+    rides_2022_dset %>%
+      filter(month(Start.Time) == month(as.Date(selected_month())) & Start.Station.Id == as.numeric(!!input$select_station_4)) %>%
       mutate(trip_date = date(Start.Time)) %>%
       group_by(trip_date, User.Type) %>%
       count() %>%
       collect() %>%
       group_by(User.Type) %>%
-      complete(trip_date = seq.Date(from = as.Date(!!input$plot_yearly_stationwise_selected),
-                                    to = as.Date(!!input$plot_yearly_stationwise_selected) + months(1) - days(1),
+      complete(trip_date = seq.Date(from = as.Date(selected_month()),
+                                    to = as.Date(selected_month()) + months(1) - days(1),
                                     by = "day")) %>%
       union_all(rides_2022_dset %>%
-                  filter(month(Start.Time) == month(as.Date(!!input$plot_yearly_stationwise_selected)) & Start.Station.Id == as.numeric(!!input$select_station_4)) %>%
+                  filter(month(Start.Time) == month(as.Date(selected_month())) & Start.Station.Id == as.numeric(!!input$select_station_4)) %>%
                   mutate(trip_date = date(Start.Time)) %>%
                   count(trip_date) %>%
                   collect() %>%
-                  complete(trip_date = seq.Date(from = as.Date(!!input$plot_yearly_stationwise_selected),
-                                                to = as.Date(!!input$plot_yearly_stationwise_selected) + months(1) - days(1),
+                  complete(trip_date = seq.Date(from = as.Date(selected_month()),
+                                                to = as.Date(selected_month()) + months(1) - days(1),
                                                 by = "day")) %>%
                   mutate(User.Type = "Total", .before = 1)
       ) %>%
       replace_na(list(n = 0))
   })
   
-  output$plot_monthly_stationwise <- renderGirafe({
-    req(monthly_rides_stationwise())
-    p_m <- ggplot(monthly_rides_stationwise(), aes(x = trip_date,
+  output$plot_monthly_swise_start <- renderGirafe({
+    req(monthly_rides_swise_start())
+    p_m <- ggplot(monthly_rides_swise_start(), aes(x = trip_date,
                                                    y = n,
                                                    group = User.Type,
                                                    colour = User.Type
@@ -214,41 +323,109 @@ server <- function(input, output, session){
                           use_stroke = TRUE),
              opts_hover(css = "stroke-width:2;"),
              opts_hover_inv(css = "opacity:0.3;"),
-             opts_selection(selected = as.Date(input$plot_yearly_stationwise_selected),
+             opts_selection(selected = as.Date(selected_day()),
                             type = "single",
                             css = "stroke:black;stroke-width:2px")
            ))
   })
   
-  daily_rides_stationwise <- reactive({
-    req(!(is.null(input$plot_monthly_stationwise_selected)))
+  monthly_rides_swise_end <- reactive({
+    req(!(is.null(selected_month())))
     rides_2022_dset %>%
-      filter(date(Start.Time) == as.Date(!!input$plot_monthly_stationwise_selected) & Start.Station.Id == as.numeric(!!input$select_station_4)) %>%
+      filter(month(End.Time) == month(as.Date(selected_month())) & End.Station.Id == as.numeric(!!input$select_station_4)) %>%
+      mutate(trip_date = date(End.Time)) %>%
+      group_by(trip_date, User.Type) %>%
+      count() %>%
+      collect() %>%
+      group_by(User.Type) %>%
+      complete(trip_date = seq.Date(from = as.Date(selected_month()),
+                                    to = as.Date(selected_month()) + months(1) - days(1),
+                                    by = "day")) %>%
+      union_all(rides_2022_dset %>%
+                  filter(month(End.Time) == month(as.Date(selected_month())) & End.Station.Id == as.numeric(!!input$select_station_4)) %>%
+                  mutate(trip_date = date(End.Time)) %>%
+                  count(trip_date) %>%
+                  collect() %>%
+                  complete(trip_date = seq.Date(from = as.Date(selected_month()),
+                                                to = as.Date(selected_month()) + months(1) - days(1),
+                                                by = "day")) %>%
+                  mutate(User.Type = "Total", .before = 1)
+      ) %>%
+      replace_na(list(n = 0))
+  })
+  
+  output$plot_monthly_swise_end <- renderGirafe({
+    req(monthly_rides_swise_end())
+    p_m <- ggplot(monthly_rides_swise_end(), aes(x = trip_date,
+                                                 y = n,
+                                                 group = User.Type,
+                                                 colour = User.Type
+    )) +
+      geom_line_interactive() +
+      geom_point_interactive(aes(tooltip = glue("{strftime(trip_date, format = '%a, %b %d')}<br/>",
+                                                "{User.Type}<br/>",
+                                                "{n} Trips<br/>"
+      ),
+      data_id = trip_date)) +
+      labs(x = "Date",
+           y = "Number of Trips",
+           colour = "User Type") + 
+      scale_x_date(date_breaks = "7 days",
+                   date_minor_breaks = "1 day",
+                   date_labels = "%b %d"
+                   # NOTE minor ticks only work from ggplot2 3.5.0
+                   # guide = guide_axis(minor.ticks = TRUE)
+      ) +
+      scale_y_continuous(limits = c(0, NA)) +
+      scale_colour_manual(values = pal_pane_4,
+                          limits = names(pal_pane_4)) +
+      theme_bikeshare() + 
+      theme(axis.ticks.x = element_line())
+    
+    # ggplotly(p) 
+    girafe(ggobj = p_m,
+           options = list(
+             opts_tooltip(use_fill = TRUE,
+                          use_stroke = TRUE),
+             opts_hover(css = "stroke-width:2;"),
+             opts_hover_inv(css = "opacity:0.3;"),
+             opts_selection(selected = as.Date(selected_day()),
+                            type = "single",
+                            css = "stroke:black;stroke-width:2px")
+           ))
+  })
+  
+  # DAILY DATA----
+  
+  daily_rides_swise_start <- reactive({
+    req(!(is.null(selected_day())))
+    rides_2022_dset %>%
+      filter(date(Start.Time) == as.Date(selected_day()) & Start.Station.Id == as.numeric(!!input$select_station_4)) %>%
       mutate(trip_hour = floor_date(Start.Time, unit = "hour")) %>%
       group_by(User.Type) %>%
       count(trip_hour) %>%
       collect() %>%
       group_by(User.Type) %>%
-      complete(trip_hour = seq(from = as.POSIXct(!!input$plot_monthly_stationwise_selected, tz = "GMT"),
-                               to = as.POSIXct(!!input$plot_monthly_stationwise_selected, tz = "GMT") + hours(24) - seconds(1),
+      complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "GMT"),
+                               to = as.POSIXct(selected_day(), tz = "GMT") + hours(24) - seconds(1),
                                by = "hour"),
       ) %>%
       union_all(rides_2022_dset %>%
-                  filter(date(Start.Time) == as.Date(!!input$plot_monthly_stationwise_selected) & Start.Station.Id == as.numeric(!!input$select_station_4)) %>%
+                  filter(date(Start.Time) == as.Date(selected_day()) & Start.Station.Id == as.numeric(!!input$select_station_4)) %>%
                   mutate(trip_hour = floor_date(Start.Time, unit = "hour")) %>%
                   count(trip_hour) %>%
                   collect() %>%
-                  complete(trip_hour = seq(from = as.POSIXct(!!input$plot_monthly_stationwise_selected, tz = "GMT"),
-                                           to = as.POSIXct(!!input$plot_monthly_stationwise_selected, tz = "GMT") + hours(24) - seconds(1),
+                  complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "GMT"),
+                                           to = as.POSIXct(selected_day(), tz = "GMT") + hours(24) - seconds(1),
                                            by = "hour")) %>%
                   mutate(User.Type = "Total", .before = 1)
       ) %>%
       replace_na(list(n = 0))
   })
   
-  output$plot_daily_stationwise <- renderGirafe({
-    req(daily_rides_stationwise())
-    p_d <- ggplot(daily_rides_stationwise(), aes(x = trip_hour,
+  output$plot_daily_swise_start <- renderGirafe({
+    req(daily_rides_swise_start())
+    p_d <- ggplot(daily_rides_swise_start(), aes(x = trip_hour,
                                            y = n,
                                            group = User.Type,
                                            colour = User.Type)) +
@@ -276,6 +453,63 @@ server <- function(input, output, session){
              opts_hover_inv(css = "opacity:0.3;")
            ))
   })
+  
+  daily_rides_swise_end <- reactive({
+  req(!(is.null(selected_day())))
+  rides_2022_dset %>%
+    filter(date(End.Time) == as.Date(selected_day()) & End.Station.Id == as.numeric(!!input$select_station_4)) %>%
+    mutate(trip_hour = floor_date(End.Time, unit = "hour")) %>%
+    group_by(User.Type) %>%
+    count(trip_hour) %>%
+    collect() %>%
+    group_by(User.Type) %>%
+    complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "GMT"),
+                             to = as.POSIXct(selected_day(), tz = "GMT") + hours(24) - seconds(1),
+                             by = "hour"),
+    ) %>%
+    union_all(rides_2022_dset %>%
+                filter(date(End.Time) == as.Date(selected_day()) & End.Station.Id == as.numeric(!!input$select_station_4)) %>%
+                mutate(trip_hour = floor_date(End.Time, unit = "hour")) %>%
+                count(trip_hour) %>%
+                collect() %>%
+                complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "GMT"),
+                                         to = as.POSIXct(selected_day(), tz = "GMT") + hours(24) - seconds(1),
+                                         by = "hour")) %>%
+                mutate(User.Type = "Total", .before = 1)
+    ) %>%
+    replace_na(list(n = 0))
+})
+
+output$plot_daily_swise_end <- renderGirafe({
+  req(daily_rides_swise_end())
+  p_d <- ggplot(daily_rides_swise_end(), aes(x = trip_hour,
+                                               y = n,
+                                               group = User.Type,
+                                               colour = User.Type)) +
+    geom_line_interactive() +
+    geom_point_interactive(aes(tooltip = glue("{strftime(trip_hour, format = '%H:%M', tz = 'GMT')}<br/>",
+                                              "{User.Type}<br/>",
+                                              "{n} Trips"),
+                               data_id = trip_hour)) +
+    labs(x = "Time",
+         y = "Number of Trips",
+         colour = "User Type") + 
+    scale_x_datetime(date_breaks = "4 hours",
+                     date_labels = "%H:%M") +
+    scale_y_continuous(limits = c(0, NA)) +
+    scale_colour_manual(values = pal_pane_4,
+                        limits = names(pal_pane_4)) +
+    theme_bikeshare() +
+    theme(axis.ticks.x = element_line())
+  
+  girafe(ggobj = p_d,
+         options = list(
+           opts_tooltip(use_fill = TRUE,
+                        use_stroke = TRUE),
+           opts_hover(css = "stroke-width:2;"),
+           opts_hover_inv(css = "opacity:0.3;")
+         ))
+})
   
 }
 

--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -83,29 +83,18 @@ for (i in (1:length(station_choices)))
                                       ")")
 
 ui <- page_fluid(
-  # layout_columns(
-  #   card(titlePanel("Placeholder")),
-  #   # card(actionButton("help_4",
-  #   #                   "Help")),
-  #   col_widths = c(6,-3,3)),
   card(selectInput("select_station_4",
-                             "Select Station:",
-                             choices = station_choices,
-                             selected = 7000)),
-  layout_column_wrap(width = 1/2,
-                     card(card_header = "Trips Started by Month",
-                          card_body = girafeOutput("plot_yearly_swise_start")),
-                     card(card_header = "Trips Ended by Month",
-                          card_body = girafeOutput("plot_yearly_swise_end")),
-                     card(card_header = "Trips Started by Day",
-                          card_body = girafeOutput("plot_monthly_swise_start")),
-                     card(card_header = "Trips Ended by Day",
-                          card_body = girafeOutput("plot_monthly_swise_end")),
-                     card(card_header = "Trips Started by Hour",
-                          card_body = girafeOutput("plot_daily_swise_start")),
-                     card(card_header = "Trips Ended by Hour",
-                          card_body = girafeOutput("plot_daily_swise_end")))
+                   "Select Station:",
+                   choices = station_choices,
+                   selected = 7000)),
+  girafeOutput("plot_yearly_swise_start"),
+  girafeOutput("plot_yearly_swise_end"),
+  girafeOutput("plot_monthly_swise_start"),
+  girafeOutput("plot_monthly_swise_end"),
+  girafeOutput("plot_daily_swise_start"),
+  girafeOutput("plot_daily_swise_end")
 )
+
 server <- function(input, output, session){
   
   # YEARLY DATA----

--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -313,7 +313,8 @@ server <- function(input, output, session){
                                                 "{n} Trips<br/>"
       ),
       data_id = trip_date)) +
-      labs(x = "Date",
+      labs(title = glue("{month(as.Date(selected_month()), label = TRUE)} {year(as.Date(selected_month()))}"),
+           x = "Date",
            y = "Number of Trips",
            colour = "User Type") + 
       scale_x_date(date_breaks = "7 days",
@@ -379,7 +380,8 @@ server <- function(input, output, session){
                                                 "{n} Trips<br/>"
       ),
       data_id = trip_date)) +
-      labs(x = "Date",
+      labs(title = glue("{month(as.Date(selected_month()), label = TRUE)} {year(as.Date(selected_month()))}"),
+           x = "Date",
            y = "Number of Trips",
            colour = "User Type") + 
       scale_x_date(date_breaks = "7 days",
@@ -446,7 +448,8 @@ server <- function(input, output, session){
                                                 "{User.Type}<br/>",
                                                 "{n} Trips"),
                                  data_id = trip_hour)) +
-      labs(x = "Time",
+      labs(title = glue("{wday(as.Date(selected_day()), label = TRUE)}, {month(as.Date(selected_day()), label = TRUE)} {day(as.Date(selected_day()))}"),
+           x = "Time",
            y = "Number of Trips",
            colour = "User Type") + 
       scale_x_datetime(date_breaks = "4 hours",
@@ -503,7 +506,8 @@ output$plot_daily_swise_end <- renderGirafe({
                                               "{User.Type}<br/>",
                                               "{n} Trips"),
                                data_id = trip_hour)) +
-    labs(x = "Time",
+    labs(title = glue("{wday(as.Date(selected_day()), label = TRUE)}, {month(as.Date(selected_day()), label = TRUE)} {day(as.Date(selected_day()))}"),
+         x = "Time",
          y = "Number of Trips",
          colour = "User Type") + 
     scale_x_datetime(date_breaks = "4 hours",

--- a/bikeshare-to-app/pane_4_draft.R
+++ b/bikeshare-to-app/pane_4_draft.R
@@ -447,7 +447,7 @@ server <- function(input, output, session){
                                            y = n,
                                            group = User.Type,
                                            colour = User.Type)) +
-      geom_line_interactive() +
+      geom_line() +
       geom_point_interactive(aes(tooltip = glue("{strftime(trip_hour, format = '%H:%M', tz = 'GMT')}<br/>",
                                                 "{User.Type}<br/>",
                                                 "{n} Trips"),
@@ -505,7 +505,7 @@ output$plot_daily_swise_end <- renderGirafe({
                                                y = n,
                                                group = User.Type,
                                                colour = User.Type)) +
-    geom_line_interactive() +
+    geom_line() +
     geom_point_interactive(aes(tooltip = glue("{strftime(trip_hour, format = '%H:%M', tz = 'GMT')}<br/>",
                                               "{User.Type}<br/>",
                                               "{n} Trips"),


### PR DESCRIPTION
The original pane 4 dev branch used a single column layout for trip start data only. A two column version that displays trip start and end data was then developed off of it. This version contains different reactive handling as well (to facilitate syncing time period selection between start and end visualizations).