### PR TITLE
Tz addition

### DIFF
--- a/Data Processing/data_loading.ipynb
+++ b/Data Processing/data_loading.ipynb
@@ -34,12 +34,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 1,
    "id": "091de1ea",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning message:\n",
+      "“package ‘tidyverse’ was built under R version 4.2.3”\n",
+      "Warning message:\n",
+      "“package ‘ggplot2’ was built under R version 4.2.3”\n",
+      "Warning message:\n",
+      "“package ‘tibble’ was built under R version 4.2.3”\n",
+      "Warning message:\n",
+      "“package ‘tidyr’ was built under R version 4.2.3”\n",
+      "Warning message:\n",
+      "“package ‘readr’ was built under R version 4.2.3”\n",
+      "Warning message:\n",
+      "“package ‘purrr’ was built under R version 4.2.3”\n",
+      "Warning message:\n",
+      "“package ‘dplyr’ was built under R version 4.2.3”\n",
+      "Warning message:\n",
+      "“package ‘stringr’ was built under R version 4.2.3”\n",
+      "Warning message:\n",
+      "“package ‘forcats’ was built under R version 4.2.3”\n",
+      "Warning message:\n",
+      "“package ‘lubridate’ was built under R version 4.2.3”\n",
+      "── \u001b[1mAttaching core tidyverse packages\u001b[22m ────────────────────────────────── tidyverse 2.0.0 ──\n",
+      "\u001b[32m✔\u001b[39m \u001b[34mdplyr    \u001b[39m 1.1.2     \u001b[32m✔\u001b[39m \u001b[34mreadr    \u001b[39m 2.1.4\n",
+      "\u001b[32m✔\u001b[39m \u001b[34mforcats  \u001b[39m 1.0.0     \u001b[32m✔\u001b[39m \u001b[34mstringr  \u001b[39m 1.5.0\n",
+      "\u001b[32m✔\u001b[39m \u001b[34mggplot2  \u001b[39m 3.4.2     \u001b[32m✔\u001b[39m \u001b[34mtibble   \u001b[39m 3.2.1\n",
+      "\u001b[32m✔\u001b[39m \u001b[34mlubridate\u001b[39m 1.9.2     \u001b[32m✔\u001b[39m \u001b[34mtidyr    \u001b[39m 1.3.0\n",
+      "\u001b[32m✔\u001b[39m \u001b[34mpurrr    \u001b[39m 1.0.1     \n",
+      "── \u001b[1mConflicts\u001b[22m ──────────────────────────────────────────────────── tidyverse_conflicts() ──\n",
+      "\u001b[31m✖\u001b[39m \u001b[34mdplyr\u001b[39m::\u001b[32mfilter()\u001b[39m masks \u001b[34mstats\u001b[39m::filter()\n",
+      "\u001b[31m✖\u001b[39m \u001b[34mdplyr\u001b[39m::\u001b[32mlag()\u001b[39m    masks \u001b[34mstats\u001b[39m::lag()\n",
+      "\u001b[36mℹ\u001b[39m Use the conflicted package (\u001b[3m\u001b[34m<http://conflicted.r-lib.org/>\u001b[39m\u001b[23m) to force all conflicts to become errors\n"
+     ]
+    }
+   ],
    "source": [
     "library(tidyverse)\n",
     "library(lubridate)"
@@ -47,20 +84,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 2,
    "id": "c395598f-aa51-4bb8-9f88-f605b81f89fb",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ERROR",
-     "evalue": "Error in setwd(\"../Data/ridership/\"): cannot change working directory\n",
-     "output_type": "error",
-     "traceback": [
-      "Error in setwd(\"../Data/ridership/\"): cannot change working directory\nTraceback:\n",
-      "1. setwd(\"../Data/ridership/\")"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "setwd(\"../Data/ridership/\")"
    ]
@@ -83,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 3,
    "id": "1b2b76a6",
    "metadata": {},
    "outputs": [],
@@ -103,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 4,
    "id": "2a192668",
    "metadata": {},
    "outputs": [],
@@ -113,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 5,
    "id": "6e38aa24",
    "metadata": {},
    "outputs": [
@@ -3123,7 +3150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 6,
    "id": "243d1856",
    "metadata": {},
    "outputs": [],
@@ -3141,7 +3168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 7,
    "id": "32eecb2b",
    "metadata": {},
    "outputs": [],
@@ -3151,7 +3178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 8,
    "id": "04f9a492",
    "metadata": {},
    "outputs": [],
@@ -3161,7 +3188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "id": "46cb94ec",
    "metadata": {},
    "outputs": [
@@ -3171,55 +3198,55 @@
        "<table class=\"dataframe\">\n",
        "<caption>A tibble: 6 × 10</caption>\n",
        "<thead>\n",
-       "\t<tr><th scope=col>Trip.Id</th><th scope=col>Trip..Duration</th><th scope=col>Start.Station.Id</th><th scope=col>Start.Time</th><th scope=col>Start.Station.Name</th><th scope=col>End.Station.Id</th><th scope=col>End.Time</th><th scope=col>End.Station.Name</th><th scope=col>Bike.Id</th><th scope=col>User.Type</th></tr>\n",
-       "\t<tr><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
+       "\t<tr><th scope=col>Trip.Id</th><th scope=col>Trip.Duration</th><th scope=col>Start.Station.Id</th><th scope=col>Start.Time</th><th scope=col>Start.Station.Name</th><th scope=col>End.Station.Id</th><th scope=col>End.Time</th><th scope=col>End.Station.Name</th><th scope=col>Bike.Id</th><th scope=col>User.Type</th></tr>\n",
+       "\t<tr><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
        "\t<tr><td>4581278</td><td>1547</td><td>7021</td><td>2019-01-01 00:08:00</td><td>Bay St / Albert St                     </td><td>7233</td><td>2019-01-01 00:33:00</td><td>King / Cowan Ave - SMART               </td><td>1296</td><td>Annual Member</td></tr>\n",
        "\t<tr><td>4581279</td><td>1112</td><td>7160</td><td>2019-01-01 00:10:00</td><td>King St W / Tecumseth St               </td><td>7051</td><td>2019-01-01 00:29:00</td><td>Wellesley St E / Yonge St (Green P)    </td><td>2947</td><td>Annual Member</td></tr>\n",
-       "\t<tr><td>4581280</td><td>589 </td><td>7055</td><td>2019-01-01 00:15:00</td><td>Jarvis St / Carlton St                 </td><td>7013</td><td>2019-01-01 00:25:00</td><td>Scott St / The Esplanade               </td><td>2293</td><td>Annual Member</td></tr>\n",
-       "\t<tr><td>4581281</td><td>259 </td><td>7012</td><td>2019-01-01 00:16:00</td><td>Elizabeth St / Edward St (Bus Terminal)</td><td>7235</td><td>2019-01-01 00:20:00</td><td>Bay St / College St (West Side) - SMART</td><td>283 </td><td>Annual Member</td></tr>\n",
-       "\t<tr><td>4581282</td><td>281 </td><td>7041</td><td>2019-01-01 00:19:00</td><td>Edward St / Yonge St                   </td><td>7257</td><td>2019-01-01 00:24:00</td><td>Dundas St W / St. Patrick St           </td><td>1799</td><td>Annual Member</td></tr>\n",
-       "\t<tr><td>4581283</td><td>624 </td><td>7041</td><td>2019-01-01 00:26:00</td><td>Edward St / Yonge St                   </td><td>7031</td><td>2019-01-01 00:36:00</td><td>Jarvis St / Isabella St                </td><td>661 </td><td>Annual Member</td></tr>\n",
+       "\t<tr><td>4581280</td><td> 589</td><td>7055</td><td>2019-01-01 00:15:00</td><td>Jarvis St / Carlton St                 </td><td>7013</td><td>2019-01-01 00:25:00</td><td>Scott St / The Esplanade               </td><td>2293</td><td>Annual Member</td></tr>\n",
+       "\t<tr><td>4581281</td><td> 259</td><td>7012</td><td>2019-01-01 00:16:00</td><td>Elizabeth St / Edward St (Bus Terminal)</td><td>7235</td><td>2019-01-01 00:20:00</td><td>Bay St / College St (West Side) - SMART</td><td>283 </td><td>Annual Member</td></tr>\n",
+       "\t<tr><td>4581282</td><td> 281</td><td>7041</td><td>2019-01-01 00:19:00</td><td>Edward St / Yonge St                   </td><td>7257</td><td>2019-01-01 00:24:00</td><td>Dundas St W / St. Patrick St           </td><td>1799</td><td>Annual Member</td></tr>\n",
+       "\t<tr><td>4581283</td><td> 624</td><td>7041</td><td>2019-01-01 00:26:00</td><td>Edward St / Yonge St                   </td><td>7031</td><td>2019-01-01 00:36:00</td><td>Jarvis St / Isabella St                </td><td>661 </td><td>Annual Member</td></tr>\n",
        "</tbody>\n",
        "</table>\n"
       ],
       "text/latex": [
        "A tibble: 6 × 10\n",
        "\\begin{tabular}{llllllllll}\n",
-       " Trip.Id & Trip..Duration & Start.Station.Id & Start.Time & Start.Station.Name & End.Station.Id & End.Time & End.Station.Name & Bike.Id & User.Type\\\\\n",
-       " <dbl> & <chr> & <chr> & <dttm> & <chr> & <chr> & <dttm> & <chr> & <chr> & <chr>\\\\\n",
+       " Trip.Id & Trip.Duration & Start.Station.Id & Start.Time & Start.Station.Name & End.Station.Id & End.Time & End.Station.Name & Bike.Id & User.Type\\\\\n",
+       " <dbl> & <dbl> & <chr> & <dttm> & <chr> & <chr> & <dttm> & <chr> & <chr> & <chr>\\\\\n",
        "\\hline\n",
        "\t 4581278 & 1547 & 7021 & 2019-01-01 00:08:00 & Bay St / Albert St                      & 7233 & 2019-01-01 00:33:00 & King / Cowan Ave - SMART                & 1296 & Annual Member\\\\\n",
        "\t 4581279 & 1112 & 7160 & 2019-01-01 00:10:00 & King St W / Tecumseth St                & 7051 & 2019-01-01 00:29:00 & Wellesley St E / Yonge St (Green P)     & 2947 & Annual Member\\\\\n",
-       "\t 4581280 & 589  & 7055 & 2019-01-01 00:15:00 & Jarvis St / Carlton St                  & 7013 & 2019-01-01 00:25:00 & Scott St / The Esplanade                & 2293 & Annual Member\\\\\n",
-       "\t 4581281 & 259  & 7012 & 2019-01-01 00:16:00 & Elizabeth St / Edward St (Bus Terminal) & 7235 & 2019-01-01 00:20:00 & Bay St / College St (West Side) - SMART & 283  & Annual Member\\\\\n",
-       "\t 4581282 & 281  & 7041 & 2019-01-01 00:19:00 & Edward St / Yonge St                    & 7257 & 2019-01-01 00:24:00 & Dundas St W / St. Patrick St            & 1799 & Annual Member\\\\\n",
-       "\t 4581283 & 624  & 7041 & 2019-01-01 00:26:00 & Edward St / Yonge St                    & 7031 & 2019-01-01 00:36:00 & Jarvis St / Isabella St                 & 661  & Annual Member\\\\\n",
+       "\t 4581280 &  589 & 7055 & 2019-01-01 00:15:00 & Jarvis St / Carlton St                  & 7013 & 2019-01-01 00:25:00 & Scott St / The Esplanade                & 2293 & Annual Member\\\\\n",
+       "\t 4581281 &  259 & 7012 & 2019-01-01 00:16:00 & Elizabeth St / Edward St (Bus Terminal) & 7235 & 2019-01-01 00:20:00 & Bay St / College St (West Side) - SMART & 283  & Annual Member\\\\\n",
+       "\t 4581282 &  281 & 7041 & 2019-01-01 00:19:00 & Edward St / Yonge St                    & 7257 & 2019-01-01 00:24:00 & Dundas St W / St. Patrick St            & 1799 & Annual Member\\\\\n",
+       "\t 4581283 &  624 & 7041 & 2019-01-01 00:26:00 & Edward St / Yonge St                    & 7031 & 2019-01-01 00:36:00 & Jarvis St / Isabella St                 & 661  & Annual Member\\\\\n",
        "\\end{tabular}\n"
       ],
       "text/markdown": [
        "\n",
        "A tibble: 6 × 10\n",
        "\n",
-       "| Trip.Id &lt;dbl&gt; | Trip..Duration &lt;chr&gt; | Start.Station.Id &lt;chr&gt; | Start.Time &lt;dttm&gt; | Start.Station.Name &lt;chr&gt; | End.Station.Id &lt;chr&gt; | End.Time &lt;dttm&gt; | End.Station.Name &lt;chr&gt; | Bike.Id &lt;chr&gt; | User.Type &lt;chr&gt; |\n",
+       "| Trip.Id &lt;dbl&gt; | Trip.Duration &lt;dbl&gt; | Start.Station.Id &lt;chr&gt; | Start.Time &lt;dttm&gt; | Start.Station.Name &lt;chr&gt; | End.Station.Id &lt;chr&gt; | End.Time &lt;dttm&gt; | End.Station.Name &lt;chr&gt; | Bike.Id &lt;chr&gt; | User.Type &lt;chr&gt; |\n",
        "|---|---|---|---|---|---|---|---|---|---|\n",
        "| 4581278 | 1547 | 7021 | 2019-01-01 00:08:00 | Bay St / Albert St                      | 7233 | 2019-01-01 00:33:00 | King / Cowan Ave - SMART                | 1296 | Annual Member |\n",
        "| 4581279 | 1112 | 7160 | 2019-01-01 00:10:00 | King St W / Tecumseth St                | 7051 | 2019-01-01 00:29:00 | Wellesley St E / Yonge St (Green P)     | 2947 | Annual Member |\n",
-       "| 4581280 | 589  | 7055 | 2019-01-01 00:15:00 | Jarvis St / Carlton St                  | 7013 | 2019-01-01 00:25:00 | Scott St / The Esplanade                | 2293 | Annual Member |\n",
-       "| 4581281 | 259  | 7012 | 2019-01-01 00:16:00 | Elizabeth St / Edward St (Bus Terminal) | 7235 | 2019-01-01 00:20:00 | Bay St / College St (West Side) - SMART | 283  | Annual Member |\n",
-       "| 4581282 | 281  | 7041 | 2019-01-01 00:19:00 | Edward St / Yonge St                    | 7257 | 2019-01-01 00:24:00 | Dundas St W / St. Patrick St            | 1799 | Annual Member |\n",
-       "| 4581283 | 624  | 7041 | 2019-01-01 00:26:00 | Edward St / Yonge St                    | 7031 | 2019-01-01 00:36:00 | Jarvis St / Isabella St                 | 661  | Annual Member |\n",
+       "| 4581280 |  589 | 7055 | 2019-01-01 00:15:00 | Jarvis St / Carlton St                  | 7013 | 2019-01-01 00:25:00 | Scott St / The Esplanade                | 2293 | Annual Member |\n",
+       "| 4581281 |  259 | 7012 | 2019-01-01 00:16:00 | Elizabeth St / Edward St (Bus Terminal) | 7235 | 2019-01-01 00:20:00 | Bay St / College St (West Side) - SMART | 283  | Annual Member |\n",
+       "| 4581282 |  281 | 7041 | 2019-01-01 00:19:00 | Edward St / Yonge St                    | 7257 | 2019-01-01 00:24:00 | Dundas St W / St. Patrick St            | 1799 | Annual Member |\n",
+       "| 4581283 |  624 | 7041 | 2019-01-01 00:26:00 | Edward St / Yonge St                    | 7031 | 2019-01-01 00:36:00 | Jarvis St / Isabella St                 | 661  | Annual Member |\n",
        "\n"
       ],
       "text/plain": [
-       "  Trip.Id Trip..Duration Start.Station.Id Start.Time         \n",
-       "1 4581278 1547           7021             2019-01-01 00:08:00\n",
-       "2 4581279 1112           7160             2019-01-01 00:10:00\n",
-       "3 4581280 589            7055             2019-01-01 00:15:00\n",
-       "4 4581281 259            7012             2019-01-01 00:16:00\n",
-       "5 4581282 281            7041             2019-01-01 00:19:00\n",
-       "6 4581283 624            7041             2019-01-01 00:26:00\n",
+       "  Trip.Id Trip.Duration Start.Station.Id Start.Time         \n",
+       "1 4581278 1547          7021             2019-01-01 00:08:00\n",
+       "2 4581279 1112          7160             2019-01-01 00:10:00\n",
+       "3 4581280  589          7055             2019-01-01 00:15:00\n",
+       "4 4581281  259          7012             2019-01-01 00:16:00\n",
+       "5 4581282  281          7041             2019-01-01 00:19:00\n",
+       "6 4581283  624          7041             2019-01-01 00:26:00\n",
        "  Start.Station.Name                      End.Station.Id End.Time           \n",
        "1 Bay St / Albert St                      7233           2019-01-01 00:33:00\n",
        "2 King St W / Tecumseth St                7051           2019-01-01 00:29:00\n",
@@ -3254,7 +3281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 10,
    "id": "9ee6ed63",
    "metadata": {},
    "outputs": [],
@@ -3264,7 +3291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 11,
    "id": "3b854134",
    "metadata": {},
    "outputs": [
@@ -3396,7 +3423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 12,
    "id": "8f7f15ec",
    "metadata": {},
    "outputs": [],
@@ -3409,7 +3436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 13,
    "id": "d30f3b2e",
    "metadata": {},
    "outputs": [
@@ -3571,7 +3598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 14,
    "id": "22735b20",
    "metadata": {},
    "outputs": [],
@@ -3581,7 +3608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 15,
    "id": "4b95490c",
    "metadata": {},
    "outputs": [],
@@ -3686,7 +3713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 16,
    "id": "88d67b6f",
    "metadata": {},
    "outputs": [],
@@ -3704,7 +3731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 17,
    "id": "ea3a7230",
    "metadata": {},
    "outputs": [],
@@ -3714,7 +3741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 18,
    "id": "2103f31a",
    "metadata": {},
    "outputs": [
@@ -3785,7 +3812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 19,
    "id": "133d9405",
    "metadata": {},
    "outputs": [
@@ -4175,7 +4202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 20,
    "id": "b18360ca",
    "metadata": {},
    "outputs": [],
@@ -4186,7 +4213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 21,
    "id": "eedd7e49",
    "metadata": {},
    "outputs": [],
@@ -4197,7 +4224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 22,
    "id": "360954f2",
    "metadata": {},
    "outputs": [],
@@ -4215,7 +4242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 23,
    "id": "af8e1ce2",
    "metadata": {},
    "outputs": [],
@@ -4228,7 +4255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 24,
    "id": "552253ce",
    "metadata": {},
    "outputs": [],
@@ -4513,7 +4540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 25,
    "id": "fb71f616",
    "metadata": {},
    "outputs": [],
@@ -4531,7 +4558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 26,
    "id": "f8bd0a5e",
    "metadata": {},
    "outputs": [],
@@ -4550,7 +4577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 27,
    "id": "becda763",
    "metadata": {},
    "outputs": [],
@@ -4570,7 +4597,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 28,
    "id": "84c0baa0",
    "metadata": {},
    "outputs": [],
@@ -4588,7 +4615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 29,
    "id": "5ebfaab4",
    "metadata": {},
    "outputs": [],
@@ -5241,12 +5268,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 31,
    "id": "006ab96c",
    "metadata": {},
    "outputs": [],
    "source": [
     "write_csv(data_all_years, \"../data_all_years.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "e50f5b5b-f9d1-4146-b380-eff10dec7902",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "write_rds(data_all_years, \"../data_all_years.rds\")"
    ]
   }
  ],

--- a/Data Processing/data_loading.ipynb
+++ b/Data Processing/data_loading.ipynb
@@ -34,49 +34,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 40,
    "id": "091de1ea",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning message:\n",
-      "“package ‘tidyverse’ was built under R version 4.2.3”\n",
-      "Warning message:\n",
-      "“package ‘ggplot2’ was built under R version 4.2.3”\n",
-      "Warning message:\n",
-      "“package ‘tibble’ was built under R version 4.2.3”\n",
-      "Warning message:\n",
-      "“package ‘tidyr’ was built under R version 4.2.3”\n",
-      "Warning message:\n",
-      "“package ‘readr’ was built under R version 4.2.3”\n",
-      "Warning message:\n",
-      "“package ‘purrr’ was built under R version 4.2.3”\n",
-      "Warning message:\n",
-      "“package ‘dplyr’ was built under R version 4.2.3”\n",
-      "Warning message:\n",
-      "“package ‘stringr’ was built under R version 4.2.3”\n",
-      "Warning message:\n",
-      "“package ‘forcats’ was built under R version 4.2.3”\n",
-      "Warning message:\n",
-      "“package ‘lubridate’ was built under R version 4.2.3”\n",
-      "── \u001b[1mAttaching core tidyverse packages\u001b[22m ────────────────────────────────── tidyverse 2.0.0 ──\n",
-      "\u001b[32m✔\u001b[39m \u001b[34mdplyr    \u001b[39m 1.1.2     \u001b[32m✔\u001b[39m \u001b[34mreadr    \u001b[39m 2.1.4\n",
-      "\u001b[32m✔\u001b[39m \u001b[34mforcats  \u001b[39m 1.0.0     \u001b[32m✔\u001b[39m \u001b[34mstringr  \u001b[39m 1.5.0\n",
-      "\u001b[32m✔\u001b[39m \u001b[34mggplot2  \u001b[39m 3.4.2     \u001b[32m✔\u001b[39m \u001b[34mtibble   \u001b[39m 3.2.1\n",
-      "\u001b[32m✔\u001b[39m \u001b[34mlubridate\u001b[39m 1.9.2     \u001b[32m✔\u001b[39m \u001b[34mtidyr    \u001b[39m 1.3.0\n",
-      "\u001b[32m✔\u001b[39m \u001b[34mpurrr    \u001b[39m 1.0.1     \n",
-      "── \u001b[1mConflicts\u001b[22m ──────────────────────────────────────────────────── tidyverse_conflicts() ──\n",
-      "\u001b[31m✖\u001b[39m \u001b[34mdplyr\u001b[39m::\u001b[32mfilter()\u001b[39m masks \u001b[34mstats\u001b[39m::filter()\n",
-      "\u001b[31m✖\u001b[39m \u001b[34mdplyr\u001b[39m::\u001b[32mlag()\u001b[39m    masks \u001b[34mstats\u001b[39m::lag()\n",
-      "\u001b[36mℹ\u001b[39m Use the conflicted package (\u001b[3m\u001b[34m<http://conflicted.r-lib.org/>\u001b[39m\u001b[23m) to force all conflicts to become errors\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "library(tidyverse)\n",
     "library(lubridate)"
@@ -84,10 +47,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 41,
    "id": "c395598f-aa51-4bb8-9f88-f605b81f89fb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ERROR",
+     "evalue": "Error in setwd(\"../Data/ridership/\"): cannot change working directory\n",
+     "output_type": "error",
+     "traceback": [
+      "Error in setwd(\"../Data/ridership/\"): cannot change working directory\nTraceback:\n",
+      "1. setwd(\"../Data/ridership/\")"
+     ]
+    }
+   ],
    "source": [
     "setwd(\"../Data/ridership/\")"
    ]
@@ -110,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 42,
    "id": "1b2b76a6",
    "metadata": {},
    "outputs": [],
@@ -130,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 43,
    "id": "2a192668",
    "metadata": {},
    "outputs": [],
@@ -140,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 44,
    "id": "6e38aa24",
    "metadata": {},
    "outputs": [
@@ -921,7 +894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 6,
    "id": "f4d1c0cb",
    "metadata": {},
    "outputs": [
@@ -1006,7 +979,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 7,
    "id": "61ebd662",
    "metadata": {
     "scrolled": true
@@ -1093,7 +1066,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 8,
    "id": "12b62f62",
    "metadata": {},
    "outputs": [
@@ -1170,7 +1143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 9,
    "id": "c1eb407a",
    "metadata": {
     "tags": []
@@ -1180,7 +1153,7 @@
      "data": {
       "text/html": [
        "<table class=\"dataframe\">\n",
-       "<caption>A tibble: 16 × 10</caption>\n",
+       "<caption>A spec_tbl_df: 16 × 10</caption>\n",
        "<thead>\n",
        "\t<tr><th scope=col>Trip.Id</th><th scope=col>Trip..Duration</th><th scope=col>Start.Station.Id</th><th scope=col>Start.Time</th><th scope=col>Start.Station.Name</th><th scope=col>End.Station.Id</th><th scope=col>End.Time</th><th scope=col>End.Station.Name</th><th scope=col>Bike.Id</th><th scope=col>User.Type</th></tr>\n",
        "\t<tr><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
@@ -1206,7 +1179,7 @@
        "</table>\n"
       ],
       "text/latex": [
-       "A tibble: 16 × 10\n",
+       "A spec\\_tbl\\_df: 16 × 10\n",
        "\\begin{tabular}{llllllllll}\n",
        " Trip.Id & Trip..Duration & Start.Station.Id & Start.Time & Start.Station.Name & End.Station.Id & End.Time & End.Station.Name & Bike.Id & User.Type\\\\\n",
        " <dbl> & <chr> & <chr> & <chr> & <chr> & <chr> & <chr> & <chr> & <chr> & <chr>\\\\\n",
@@ -1231,7 +1204,7 @@
       ],
       "text/markdown": [
        "\n",
-       "A tibble: 16 × 10\n",
+       "A spec_tbl_df: 16 × 10\n",
        "\n",
        "| Trip.Id &lt;dbl&gt; | Trip..Duration &lt;chr&gt; | Start.Station.Id &lt;chr&gt; | Start.Time &lt;chr&gt; | Start.Station.Name &lt;chr&gt; | End.Station.Id &lt;chr&gt; | End.Time &lt;chr&gt; | End.Station.Name &lt;chr&gt; | Bike.Id &lt;chr&gt; | User.Type &lt;chr&gt; |\n",
        "|---|---|---|---|---|---|---|---|---|---|\n",
@@ -1342,7 +1315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 10,
    "id": "1aae84ff",
    "metadata": {},
    "outputs": [
@@ -1827,7 +1800,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 11,
    "id": "f79e66b1",
    "metadata": {},
    "outputs": [
@@ -3150,7 +3123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 45,
    "id": "243d1856",
    "metadata": {},
    "outputs": [],
@@ -3168,7 +3141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 46,
    "id": "32eecb2b",
    "metadata": {},
    "outputs": [],
@@ -3178,17 +3151,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 47,
    "id": "04f9a492",
    "metadata": {},
    "outputs": [],
    "source": [
-    "current_format_data <- current_format_data %>% mutate(across(c(Start.Time, End.Time), mdy_hm))"
+    "current_format_data <- current_format_data %>% mutate(across(c(Start.Time, End.Time), ~mdy_hm(.x, tz = \"America/Toronto\")))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 14,
    "id": "46cb94ec",
    "metadata": {},
    "outputs": [
@@ -3198,55 +3171,55 @@
        "<table class=\"dataframe\">\n",
        "<caption>A tibble: 6 × 10</caption>\n",
        "<thead>\n",
-       "\t<tr><th scope=col>Trip.Id</th><th scope=col>Trip.Duration</th><th scope=col>Start.Station.Id</th><th scope=col>Start.Time</th><th scope=col>Start.Station.Name</th><th scope=col>End.Station.Id</th><th scope=col>End.Time</th><th scope=col>End.Station.Name</th><th scope=col>Bike.Id</th><th scope=col>User.Type</th></tr>\n",
-       "\t<tr><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
+       "\t<tr><th scope=col>Trip.Id</th><th scope=col>Trip..Duration</th><th scope=col>Start.Station.Id</th><th scope=col>Start.Time</th><th scope=col>Start.Station.Name</th><th scope=col>End.Station.Id</th><th scope=col>End.Time</th><th scope=col>End.Station.Name</th><th scope=col>Bike.Id</th><th scope=col>User.Type</th></tr>\n",
+       "\t<tr><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
        "\t<tr><td>4581278</td><td>1547</td><td>7021</td><td>2019-01-01 00:08:00</td><td>Bay St / Albert St                     </td><td>7233</td><td>2019-01-01 00:33:00</td><td>King / Cowan Ave - SMART               </td><td>1296</td><td>Annual Member</td></tr>\n",
        "\t<tr><td>4581279</td><td>1112</td><td>7160</td><td>2019-01-01 00:10:00</td><td>King St W / Tecumseth St               </td><td>7051</td><td>2019-01-01 00:29:00</td><td>Wellesley St E / Yonge St (Green P)    </td><td>2947</td><td>Annual Member</td></tr>\n",
-       "\t<tr><td>4581280</td><td> 589</td><td>7055</td><td>2019-01-01 00:15:00</td><td>Jarvis St / Carlton St                 </td><td>7013</td><td>2019-01-01 00:25:00</td><td>Scott St / The Esplanade               </td><td>2293</td><td>Annual Member</td></tr>\n",
-       "\t<tr><td>4581281</td><td> 259</td><td>7012</td><td>2019-01-01 00:16:00</td><td>Elizabeth St / Edward St (Bus Terminal)</td><td>7235</td><td>2019-01-01 00:20:00</td><td>Bay St / College St (West Side) - SMART</td><td>283 </td><td>Annual Member</td></tr>\n",
-       "\t<tr><td>4581282</td><td> 281</td><td>7041</td><td>2019-01-01 00:19:00</td><td>Edward St / Yonge St                   </td><td>7257</td><td>2019-01-01 00:24:00</td><td>Dundas St W / St. Patrick St           </td><td>1799</td><td>Annual Member</td></tr>\n",
-       "\t<tr><td>4581283</td><td> 624</td><td>7041</td><td>2019-01-01 00:26:00</td><td>Edward St / Yonge St                   </td><td>7031</td><td>2019-01-01 00:36:00</td><td>Jarvis St / Isabella St                </td><td>661 </td><td>Annual Member</td></tr>\n",
+       "\t<tr><td>4581280</td><td>589 </td><td>7055</td><td>2019-01-01 00:15:00</td><td>Jarvis St / Carlton St                 </td><td>7013</td><td>2019-01-01 00:25:00</td><td>Scott St / The Esplanade               </td><td>2293</td><td>Annual Member</td></tr>\n",
+       "\t<tr><td>4581281</td><td>259 </td><td>7012</td><td>2019-01-01 00:16:00</td><td>Elizabeth St / Edward St (Bus Terminal)</td><td>7235</td><td>2019-01-01 00:20:00</td><td>Bay St / College St (West Side) - SMART</td><td>283 </td><td>Annual Member</td></tr>\n",
+       "\t<tr><td>4581282</td><td>281 </td><td>7041</td><td>2019-01-01 00:19:00</td><td>Edward St / Yonge St                   </td><td>7257</td><td>2019-01-01 00:24:00</td><td>Dundas St W / St. Patrick St           </td><td>1799</td><td>Annual Member</td></tr>\n",
+       "\t<tr><td>4581283</td><td>624 </td><td>7041</td><td>2019-01-01 00:26:00</td><td>Edward St / Yonge St                   </td><td>7031</td><td>2019-01-01 00:36:00</td><td>Jarvis St / Isabella St                </td><td>661 </td><td>Annual Member</td></tr>\n",
        "</tbody>\n",
        "</table>\n"
       ],
       "text/latex": [
        "A tibble: 6 × 10\n",
        "\\begin{tabular}{llllllllll}\n",
-       " Trip.Id & Trip.Duration & Start.Station.Id & Start.Time & Start.Station.Name & End.Station.Id & End.Time & End.Station.Name & Bike.Id & User.Type\\\\\n",
-       " <dbl> & <dbl> & <chr> & <dttm> & <chr> & <chr> & <dttm> & <chr> & <chr> & <chr>\\\\\n",
+       " Trip.Id & Trip..Duration & Start.Station.Id & Start.Time & Start.Station.Name & End.Station.Id & End.Time & End.Station.Name & Bike.Id & User.Type\\\\\n",
+       " <dbl> & <chr> & <chr> & <dttm> & <chr> & <chr> & <dttm> & <chr> & <chr> & <chr>\\\\\n",
        "\\hline\n",
        "\t 4581278 & 1547 & 7021 & 2019-01-01 00:08:00 & Bay St / Albert St                      & 7233 & 2019-01-01 00:33:00 & King / Cowan Ave - SMART                & 1296 & Annual Member\\\\\n",
        "\t 4581279 & 1112 & 7160 & 2019-01-01 00:10:00 & King St W / Tecumseth St                & 7051 & 2019-01-01 00:29:00 & Wellesley St E / Yonge St (Green P)     & 2947 & Annual Member\\\\\n",
-       "\t 4581280 &  589 & 7055 & 2019-01-01 00:15:00 & Jarvis St / Carlton St                  & 7013 & 2019-01-01 00:25:00 & Scott St / The Esplanade                & 2293 & Annual Member\\\\\n",
-       "\t 4581281 &  259 & 7012 & 2019-01-01 00:16:00 & Elizabeth St / Edward St (Bus Terminal) & 7235 & 2019-01-01 00:20:00 & Bay St / College St (West Side) - SMART & 283  & Annual Member\\\\\n",
-       "\t 4581282 &  281 & 7041 & 2019-01-01 00:19:00 & Edward St / Yonge St                    & 7257 & 2019-01-01 00:24:00 & Dundas St W / St. Patrick St            & 1799 & Annual Member\\\\\n",
-       "\t 4581283 &  624 & 7041 & 2019-01-01 00:26:00 & Edward St / Yonge St                    & 7031 & 2019-01-01 00:36:00 & Jarvis St / Isabella St                 & 661  & Annual Member\\\\\n",
+       "\t 4581280 & 589  & 7055 & 2019-01-01 00:15:00 & Jarvis St / Carlton St                  & 7013 & 2019-01-01 00:25:00 & Scott St / The Esplanade                & 2293 & Annual Member\\\\\n",
+       "\t 4581281 & 259  & 7012 & 2019-01-01 00:16:00 & Elizabeth St / Edward St (Bus Terminal) & 7235 & 2019-01-01 00:20:00 & Bay St / College St (West Side) - SMART & 283  & Annual Member\\\\\n",
+       "\t 4581282 & 281  & 7041 & 2019-01-01 00:19:00 & Edward St / Yonge St                    & 7257 & 2019-01-01 00:24:00 & Dundas St W / St. Patrick St            & 1799 & Annual Member\\\\\n",
+       "\t 4581283 & 624  & 7041 & 2019-01-01 00:26:00 & Edward St / Yonge St                    & 7031 & 2019-01-01 00:36:00 & Jarvis St / Isabella St                 & 661  & Annual Member\\\\\n",
        "\\end{tabular}\n"
       ],
       "text/markdown": [
        "\n",
        "A tibble: 6 × 10\n",
        "\n",
-       "| Trip.Id &lt;dbl&gt; | Trip.Duration &lt;dbl&gt; | Start.Station.Id &lt;chr&gt; | Start.Time &lt;dttm&gt; | Start.Station.Name &lt;chr&gt; | End.Station.Id &lt;chr&gt; | End.Time &lt;dttm&gt; | End.Station.Name &lt;chr&gt; | Bike.Id &lt;chr&gt; | User.Type &lt;chr&gt; |\n",
+       "| Trip.Id &lt;dbl&gt; | Trip..Duration &lt;chr&gt; | Start.Station.Id &lt;chr&gt; | Start.Time &lt;dttm&gt; | Start.Station.Name &lt;chr&gt; | End.Station.Id &lt;chr&gt; | End.Time &lt;dttm&gt; | End.Station.Name &lt;chr&gt; | Bike.Id &lt;chr&gt; | User.Type &lt;chr&gt; |\n",
        "|---|---|---|---|---|---|---|---|---|---|\n",
        "| 4581278 | 1547 | 7021 | 2019-01-01 00:08:00 | Bay St / Albert St                      | 7233 | 2019-01-01 00:33:00 | King / Cowan Ave - SMART                | 1296 | Annual Member |\n",
        "| 4581279 | 1112 | 7160 | 2019-01-01 00:10:00 | King St W / Tecumseth St                | 7051 | 2019-01-01 00:29:00 | Wellesley St E / Yonge St (Green P)     | 2947 | Annual Member |\n",
-       "| 4581280 |  589 | 7055 | 2019-01-01 00:15:00 | Jarvis St / Carlton St                  | 7013 | 2019-01-01 00:25:00 | Scott St / The Esplanade                | 2293 | Annual Member |\n",
-       "| 4581281 |  259 | 7012 | 2019-01-01 00:16:00 | Elizabeth St / Edward St (Bus Terminal) | 7235 | 2019-01-01 00:20:00 | Bay St / College St (West Side) - SMART | 283  | Annual Member |\n",
-       "| 4581282 |  281 | 7041 | 2019-01-01 00:19:00 | Edward St / Yonge St                    | 7257 | 2019-01-01 00:24:00 | Dundas St W / St. Patrick St            | 1799 | Annual Member |\n",
-       "| 4581283 |  624 | 7041 | 2019-01-01 00:26:00 | Edward St / Yonge St                    | 7031 | 2019-01-01 00:36:00 | Jarvis St / Isabella St                 | 661  | Annual Member |\n",
+       "| 4581280 | 589  | 7055 | 2019-01-01 00:15:00 | Jarvis St / Carlton St                  | 7013 | 2019-01-01 00:25:00 | Scott St / The Esplanade                | 2293 | Annual Member |\n",
+       "| 4581281 | 259  | 7012 | 2019-01-01 00:16:00 | Elizabeth St / Edward St (Bus Terminal) | 7235 | 2019-01-01 00:20:00 | Bay St / College St (West Side) - SMART | 283  | Annual Member |\n",
+       "| 4581282 | 281  | 7041 | 2019-01-01 00:19:00 | Edward St / Yonge St                    | 7257 | 2019-01-01 00:24:00 | Dundas St W / St. Patrick St            | 1799 | Annual Member |\n",
+       "| 4581283 | 624  | 7041 | 2019-01-01 00:26:00 | Edward St / Yonge St                    | 7031 | 2019-01-01 00:36:00 | Jarvis St / Isabella St                 | 661  | Annual Member |\n",
        "\n"
       ],
       "text/plain": [
-       "  Trip.Id Trip.Duration Start.Station.Id Start.Time         \n",
-       "1 4581278 1547          7021             2019-01-01 00:08:00\n",
-       "2 4581279 1112          7160             2019-01-01 00:10:00\n",
-       "3 4581280  589          7055             2019-01-01 00:15:00\n",
-       "4 4581281  259          7012             2019-01-01 00:16:00\n",
-       "5 4581282  281          7041             2019-01-01 00:19:00\n",
-       "6 4581283  624          7041             2019-01-01 00:26:00\n",
+       "  Trip.Id Trip..Duration Start.Station.Id Start.Time         \n",
+       "1 4581278 1547           7021             2019-01-01 00:08:00\n",
+       "2 4581279 1112           7160             2019-01-01 00:10:00\n",
+       "3 4581280 589            7055             2019-01-01 00:15:00\n",
+       "4 4581281 259            7012             2019-01-01 00:16:00\n",
+       "5 4581282 281            7041             2019-01-01 00:19:00\n",
+       "6 4581283 624            7041             2019-01-01 00:26:00\n",
        "  Start.Station.Name                      End.Station.Id End.Time           \n",
        "1 Bay St / Albert St                      7233           2019-01-01 00:33:00\n",
        "2 King St W / Tecumseth St                7051           2019-01-01 00:29:00\n",
@@ -3281,7 +3254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 48,
    "id": "9ee6ed63",
    "metadata": {},
    "outputs": [],
@@ -3291,7 +3264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 49,
    "id": "3b854134",
    "metadata": {},
    "outputs": [
@@ -3423,7 +3396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 50,
    "id": "8f7f15ec",
    "metadata": {},
    "outputs": [],
@@ -3436,7 +3409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 51,
    "id": "d30f3b2e",
    "metadata": {},
    "outputs": [
@@ -3598,7 +3571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 52,
    "id": "22735b20",
    "metadata": {},
    "outputs": [],
@@ -3608,17 +3581,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 53,
    "id": "4b95490c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_2018_reformat <- data_2018_reformat %>% mutate(across(c(Start.Time, End.Time), mdy_hm))"
+    "data_2018_reformat <- data_2018_reformat %>% mutate(across(c(Start.Time, End.Time), ~mdy_hm(.x, tz = \"America/Toronto\")))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 23,
    "id": "eb66420b",
    "metadata": {
     "scrolled": true
@@ -3630,7 +3603,7 @@
        "<table class=\"dataframe\">\n",
        "<caption>A tibble: 6 × 9</caption>\n",
        "<thead>\n",
-       "\t<tr><th scope=col>Trip.Id</th><th scope=col>Trip.Duration</th><th scope=col>Start.Station.Id</th><th scope=col>Start.Time</th><th scope=col>Start.Station.Name</th><th scope=col>End.Station.Id</th><th scope=col>End.Time</th><th scope=col>End.Station.Name</th><th scope=col>User.Type</th></tr>\n",
+       "\t<tr><th scope=col>Trip.Id</th><th scope=col>Trip..Duration</th><th scope=col>Start.Station.Id</th><th scope=col>Start.Time</th><th scope=col>Start.Station.Name</th><th scope=col>End.Station.Id</th><th scope=col>End.Time</th><th scope=col>End.Station.Name</th><th scope=col>User.Type</th></tr>\n",
        "\t<tr><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;dbl&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;dttm&gt;</th><th scope=col>&lt;chr&gt;</th><th scope=col>&lt;chr&gt;</th></tr>\n",
        "</thead>\n",
        "<tbody>\n",
@@ -3646,7 +3619,7 @@
       "text/latex": [
        "A tibble: 6 × 9\n",
        "\\begin{tabular}{lllllllll}\n",
-       " Trip.Id & Trip.Duration & Start.Station.Id & Start.Time & Start.Station.Name & End.Station.Id & End.Time & End.Station.Name & User.Type\\\\\n",
+       " Trip.Id & Trip..Duration & Start.Station.Id & Start.Time & Start.Station.Name & End.Station.Id & End.Time & End.Station.Name & User.Type\\\\\n",
        " <dbl> & <dbl> & <chr> & <dttm> & <chr> & <chr> & <dttm> & <chr> & <chr>\\\\\n",
        "\\hline\n",
        "\t 2383648 &  393 & 7018 & 2018-01-01 00:47:00 & Bremner Blvd / Rees St                  & 7176 & 2018-01-01 00:54:00 & Bathurst St / Fort York Blvd & Annual Member\\\\\n",
@@ -3661,7 +3634,7 @@
        "\n",
        "A tibble: 6 × 9\n",
        "\n",
-       "| Trip.Id &lt;dbl&gt; | Trip.Duration &lt;dbl&gt; | Start.Station.Id &lt;chr&gt; | Start.Time &lt;dttm&gt; | Start.Station.Name &lt;chr&gt; | End.Station.Id &lt;chr&gt; | End.Time &lt;dttm&gt; | End.Station.Name &lt;chr&gt; | User.Type &lt;chr&gt; |\n",
+       "| Trip.Id &lt;dbl&gt; | Trip..Duration &lt;dbl&gt; | Start.Station.Id &lt;chr&gt; | Start.Time &lt;dttm&gt; | Start.Station.Name &lt;chr&gt; | End.Station.Id &lt;chr&gt; | End.Time &lt;dttm&gt; | End.Station.Name &lt;chr&gt; | User.Type &lt;chr&gt; |\n",
        "|---|---|---|---|---|---|---|---|---|\n",
        "| 2383648 |  393 | 7018 | 2018-01-01 00:47:00 | Bremner Blvd / Rees St                  | 7176 | 2018-01-01 00:54:00 | Bathurst St / Fort York Blvd | Annual Member |\n",
        "| 2383649 |  625 | 7184 | 2018-01-01 00:52:00 | Ossington Ave / College St              | 7191 | 2018-01-01 01:03:00 | Central Tech  (Harbord St)   | Annual Member |\n",
@@ -3672,13 +3645,13 @@
        "\n"
       ],
       "text/plain": [
-       "  Trip.Id Trip.Duration Start.Station.Id Start.Time         \n",
-       "1 2383648  393          7018             2018-01-01 00:47:00\n",
-       "2 2383649  625          7184             2018-01-01 00:52:00\n",
-       "3 2383650  233          7235             2018-01-01 00:55:00\n",
-       "4 2383651 1138          7202             2018-01-01 00:57:00\n",
-       "5 2383652  703          7004             2018-01-01 01:00:00\n",
-       "6 2383653 1026          7078             2018-01-01 01:07:00\n",
+       "  Trip.Id Trip..Duration Start.Station.Id Start.Time         \n",
+       "1 2383648  393           7018             2018-01-01 00:47:00\n",
+       "2 2383649  625           7184             2018-01-01 00:52:00\n",
+       "3 2383650  233           7235             2018-01-01 00:55:00\n",
+       "4 2383651 1138           7202             2018-01-01 00:57:00\n",
+       "5 2383652  703           7004             2018-01-01 01:00:00\n",
+       "6 2383653 1026           7078             2018-01-01 01:07:00\n",
        "  Start.Station.Name                      End.Station.Id End.Time           \n",
        "1 Bremner Blvd / Rees St                  7176           2018-01-01 00:54:00\n",
        "2 Ossington Ave / College St              7191           2018-01-01 01:03:00\n",
@@ -3713,7 +3686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 54,
    "id": "88d67b6f",
    "metadata": {},
    "outputs": [],
@@ -3731,7 +3704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 55,
    "id": "ea3a7230",
    "metadata": {},
    "outputs": [],
@@ -3741,7 +3714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 56,
    "id": "2103f31a",
    "metadata": {},
    "outputs": [
@@ -3812,7 +3785,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 57,
    "id": "133d9405",
    "metadata": {},
    "outputs": [
@@ -4202,7 +4175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 58,
    "id": "b18360ca",
    "metadata": {},
    "outputs": [],
@@ -4213,7 +4186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 59,
    "id": "eedd7e49",
    "metadata": {},
    "outputs": [],
@@ -4224,7 +4197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 60,
    "id": "360954f2",
    "metadata": {},
    "outputs": [],
@@ -4242,7 +4215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 61,
    "id": "af8e1ce2",
    "metadata": {},
    "outputs": [],
@@ -4255,7 +4228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 62,
    "id": "552253ce",
    "metadata": {},
    "outputs": [],
@@ -4540,7 +4513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 63,
    "id": "fb71f616",
    "metadata": {},
    "outputs": [],
@@ -4558,13 +4531,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 64,
    "id": "f8bd0a5e",
    "metadata": {},
    "outputs": [],
    "source": [
     "data_2017_reformat <- data_2017_reformat %>% mutate(across(c(Start.Station.Id, End.Station.Id), as.character)) %>%\n",
-    "    mutate(across(c(Start.Time, End.Time), ~parse_date_time(.x, c(\"dmy_HM\", \"mdy_HM\", \"mdy_HMS\"))))"
+    "    mutate(across(c(Start.Time, End.Time), ~parse_date_time(.x, c(\"dmy_HM\", \"mdy_HM\", \"mdy_HMS\"), tz = \"America/Toronto\")))"
    ]
   },
   {
@@ -4577,7 +4550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 65,
    "id": "becda763",
    "metadata": {},
    "outputs": [],
@@ -4597,7 +4570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 66,
    "id": "84c0baa0",
    "metadata": {},
    "outputs": [],
@@ -4615,7 +4588,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 67,
    "id": "5ebfaab4",
    "metadata": {},
    "outputs": [],
@@ -5268,7 +5241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 69,
    "id": "006ab96c",
    "metadata": {},
    "outputs": [],

--- a/Data Processing/ride_data_2022_sf.R
+++ b/Data Processing/ride_data_2022_sf.R
@@ -3,10 +3,11 @@ library(sf)
 library(arrow)
 
 stations_sf <- readRDS("./Data/stations_update_2022_sf.rds")
-data_all_years <- read_csv("./Data/data_all_years.csv")
+data_all_years <- read_rds("./Data/data_all_years.rds")
 
 rides_2022_cleaned <- data_all_years %>%
-  filter(Start.Station.Id %in% stations_sf$station_id & End.Station.Id %in% stations_sf$station_id & year(Start.Time) == 2022)
+  filter(Start.Station.Id %in% stations_sf$station_id & End.Station.Id %in% stations_sf$station_id & year(Start.Time) == 2022) %>%
+  mutate(across(c(Start.Station.Id, End.Station.Id), as.numeric))
 
 saveRDS(rides_2022_cleaned, "./Data/rides_2022_cleaned.rds")
 write_dataset(rides_2022_cleaned, path = "./Data/rides_2022_cleaned")

--- a/bikeshare-to-app/app.R
+++ b/bikeshare-to-app/app.R
@@ -1231,8 +1231,8 @@ The time period chosen is synchronized between the plots for Trips Started and T
       count(trip_hour) %>%
       collect() %>%
       group_by(User.Type) %>%
-      complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "GMT"),
-                               to = as.POSIXct(selected_day(), tz = "GMT") + hours(24) - seconds(1),
+      complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "America/Toronto"),
+                               to = as.POSIXct(selected_day(), tz = "America/Toronto") + hours(24) - seconds(1),
                                by = "hour"),
       ) %>%
       union_all(rides_2022_dset %>%
@@ -1240,8 +1240,8 @@ The time period chosen is synchronized between the plots for Trips Started and T
                   mutate(trip_hour = floor_date(Start.Time, unit = "hour")) %>%
                   count(trip_hour) %>%
                   collect() %>%
-                  complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "GMT"),
-                                           to = as.POSIXct(selected_day(), tz = "GMT") + hours(24) - seconds(1),
+                  complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "America/Toronto"),
+                                           to = as.POSIXct(selected_day(), tz = "America/Toronto") + hours(24) - seconds(1),
                                            by = "hour")) %>%
                   mutate(User.Type = "Total", .before = 1)
       ) %>%
@@ -1255,7 +1255,7 @@ The time period chosen is synchronized between the plots for Trips Started and T
                                                  group = User.Type,
                                                  colour = User.Type)) +
       geom_line() +
-      geom_point_interactive(aes(tooltip = glue("{strftime(trip_hour, format = '%H:%M', tz = 'GMT')}<br/>",
+      geom_point_interactive(aes(tooltip = glue("{strftime(trip_hour, format = '%H:%M', tz = 'America/Toronto')}<br/>",
                                                 "{User.Type}<br/>",
                                                 "{n} Trips"),
                                  data_id = trip_hour)) +
@@ -1289,8 +1289,8 @@ The time period chosen is synchronized between the plots for Trips Started and T
       count(trip_hour) %>%
       collect() %>%
       group_by(User.Type) %>%
-      complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "GMT"),
-                               to = as.POSIXct(selected_day(), tz = "GMT") + hours(24) - seconds(1),
+      complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "America/Toronto"),
+                               to = as.POSIXct(selected_day(), tz = "America/Toronto") + hours(24) - seconds(1),
                                by = "hour"),
       ) %>%
       union_all(rides_2022_dset %>%
@@ -1298,8 +1298,8 @@ The time period chosen is synchronized between the plots for Trips Started and T
                   mutate(trip_hour = floor_date(End.Time, unit = "hour")) %>%
                   count(trip_hour) %>%
                   collect() %>%
-                  complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "GMT"),
-                                           to = as.POSIXct(selected_day(), tz = "GMT") + hours(24) - seconds(1),
+                  complete(trip_hour = seq(from = as.POSIXct(selected_day(), tz = "America/Toronto"),
+                                           to = as.POSIXct(selected_day(), tz = "America/Toronto") + hours(24) - seconds(1),
                                            by = "hour")) %>%
                   mutate(User.Type = "Total", .before = 1)
       ) %>%
@@ -1313,7 +1313,7 @@ The time period chosen is synchronized between the plots for Trips Started and T
                                                group = User.Type,
                                                colour = User.Type)) +
       geom_line() +
-      geom_point_interactive(aes(tooltip = glue("{strftime(trip_hour, format = '%H:%M', tz = 'GMT')}<br/>",
+      geom_point_interactive(aes(tooltip = glue("{strftime(trip_hour, format = '%H:%M', tz = 'America/Toronto')}<br/>",
                                                 "{User.Type}<br/>",
                                                 "{n} Trips"),
                                  data_id = trip_hour)) +


### PR DESCRIPTION
Previously the time zone of the ride data was never explicitly set, meaning it was defaulting to UTC. This caused issues when some POSIX objects were being created using local time. This was corrected in the interim by explicitly setting `tz = "GMT"` when creating POSIX objects to match the data.

This issue has now been corrected more apporpriately by setting the time zone explicitly in the [data loading notebook](Data Processing/data_loading.ipynb) as `tz = "America/Toronto". The data was then exported as an RDS to preserve tz info, which was used when creating the 2022 dataset for the app. 

In the app, when POSIX objects are created, the tz is now set to "America/Toronto" to match the data rather than to "GMT".